### PR TITLE
Switch semver check to use coerce for invalid semvers, fixes #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,12 +68,12 @@
     },
     "dependencies": {
         "rxjs": "^5.4.0",
-        "semver": "^5.3.0",
+        "semver": "^5.5.0",
         "tmp": "^0.0.31"
     },
     "devDependencies": {
         "@types/node": "^6.0.40",
-        "@types/semver": "^5.3.31",
+        "@types/semver": "^5.5.0",
         "@types/tmp": "^0.0.33",
         "tslint": "^5.2.0",
         "tslint-immutable": "^4.0.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -422,10 +422,11 @@ const getExpectedVersion = (
         const matches = stdout.match(pattern);
         if (matches && matches.length === 2) {
             const version = matches[1];
-            // Compare ranges loosely since we might not get a totally valid
-            // semantic version from the program
-            if (semver.satisfies(version, range, true)) {
-                return version;
+            // Attempt to coerce whatever version hlint reports into a valid
+            // semantic version, then compare that against our range
+            const coerced = semver.coerce(version);
+            if (coerced && semver.satisfies(coerced, range)) {
+                return coerced.version;
             } else {
                 // tslint:disable-next-line:max-line-length
                 throw new VersionError(`${program} version ${version} did not meet requirements ${range}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "6.0.85"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.85.tgz#ec02bfe54a61044f2be44f13b389c6a0e8ee05ae"
 
-"@types/semver@^5.3.31":
-  version "5.3.33"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.3.33.tgz#58ebb6c8c48e161e24f8901915e7184900d341f7"
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
 
 "@types/tmp@^0.0.33":
   version "0.0.33"
@@ -1328,6 +1328,10 @@ safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
Fixes #7, tested and works fine for me using hlint 2.1:

![](https://i.imgur.com/ouotVss.png)

Because it's now using coerce I decided to remove the loose check, I did some testing with the semver library and [this should still function as intended, even with correct semvers](https://i.imgur.com/k6Px52h.png), but I'm not really experienced with TS or the semver library so let me know if I've clearly missed something